### PR TITLE
feat: add domains for Japanese government and local authorities

### DIFF
--- a/projects/config/index.ts
+++ b/projects/config/index.ts
@@ -39,6 +39,10 @@ export const config = {
     name: "Island of Jersey",
     domains: [".gov.je"],
   },
+  jp: {
+    name: "Japan",
+    domains: [".go.jp"],
+  },
   ua: {
     name: "Ukraine",
     domains: [".gov.ua"],

--- a/projects/config/index.ts
+++ b/projects/config/index.ts
@@ -41,7 +41,7 @@ export const config = {
   },
   jp: {
     name: "Japan",
-    domains: [".go.jp"],
+    domains: [".go.jp", ".metro.tokyo.jp"],
   },
   ua: {
     name: "Ukraine",

--- a/projects/config/index.ts
+++ b/projects/config/index.ts
@@ -41,7 +41,7 @@ export const config = {
   },
   jp: {
     name: "Japan",
-    domains: [".go.jp", ".metro.tokyo.jp"],
+    domains: [".go.jp", ".lg.jp", ".metro.tokyo.jp"],
   },
   ua: {
     name: "Ukraine",


### PR DESCRIPTION
Hello, thanks for creating a nice project! 😀 

This PR adds three domains `*.go.jp`, `*.lg.jp`, and `*.metro.tokyo.jp` for governments in Japan.

This article provides an overview of Japanese governmental domains: .jp - Wikipedia - https://en.wikipedia.org/wiki/.jp

## go.jp
The `go.jp` is reserved only for governments and ministries (departments) in Japan.

Examples:
- The Government of Japan - JapanGov - https://www.japan.go.jp/
- Ministry of Foreign Affairs of Japan - https://www.mofa.go.jp/

## lg.jp
The `lg.jp` is reserved for local governments.

Examples:
- Tokyo Metropolitan Gov​ - https://www.english.metro.tokyo.lg.jp/

## metro.tokyo.jp
The `metro.tokyo.jp` is reversed for the Tokyo Metropolitan Government. This domain is sometimes used as alias to `*.metro.tokyo.lg.jp`, but sometimes not.

Examples:
- Tokyo Metropolitan Government - https://www.metro.tokyo.lg.jp
- TOEI TRANSPORTATION - https://www.kotsu.metro.tokyo.jp/eng/
  - train service managed by Tokyo Metropolitan government

## Additional notes
Unlike the US (`*.gov`), local governmental domain names are not always under one domain in Japan. In many cases, they use `*.lg.jp` domain, but some of them (or some of their branches) use other variants `pref.<pref-name>.jp` (like https://www.pref.kyoto.jp/) inconsistently. There are over 40 variants for this subtype, so I only added one variant for Tokyo Metropolitan Government (`metro.tokyo.jp`) for now. Probably, we can add other variants in the future.

As a side note, we observed bad practices in the past, where governmental organizations did not use reserved domains properly and just chose commercial ones (like `*.com` or `*.jp`) for important websites repeatedly. If they will create a Bluesky account with such domains in the future, it would be difficult to cover all of them.

Unfortunately, most organizations in Japan regardless of public or private sectors (and most individuals, even web developers) continue using the closed social media exclusively. And I couldn't find any account with one of the above domains at this moment. But this project should help us to track the new Blusky migrations easily.