### PR TITLE
feat: add domains for Malaysia, Philippines,Singapore, and Vietnam governments

### DIFF
--- a/projects/config/index.ts
+++ b/projects/config/index.ts
@@ -39,6 +39,10 @@ export const config = {
     name: "Island of Jersey",
     domains: [".gov.je"],
   },
+  my:  {
+    name: "Malaysia",
+    domains: [".gov.my"]
+  },
   ua: {
     name: "Ukraine",
     domains: [".gov.ua"],

--- a/projects/config/index.ts
+++ b/projects/config/index.ts
@@ -43,6 +43,14 @@ export const config = {
     name: "Malaysia",
     domains: [".gov.my"]
   },
+  ph: {
+    name: "Philippines",
+    domains: [".gov.ph"],
+  },
+  sg: {
+    name: "Singapore",
+    domains: [".gov.sg"],
+  },
   ua: {
     name: "Ukraine",
     domains: [".gov.ua"],
@@ -54,6 +62,10 @@ export const config = {
   us: {
     name: "United States",
     domains: [".gov", ".mil"],
+  },
+  vn: {
+    name: "Vietnam",
+    domains: [".gov.vn"],
   },
 } as const;
 


### PR DESCRIPTION
resolve #5

## Malaysia `.gov.my`
I double-checked `.gov.my` with the following:
- https://en.wikipedia.org/wiki/.my#Domain_name_categories
- https://en.wikipedia.org/wiki/Government_of_Malaysia
- https://www.malaysia.gov.my/portal/index

Also, it looks like local authorities are under `*.gov.my` like US states (`*.gov`): https://www.malaysia.gov.my/portal/content/31386

## Philippines `.gov.ph`

> In 1994, the administration of the .gov.ph domain was sub-delegated to the [Government of the Philippines](https://en.wikipedia.org/wiki/Government_of_the_Philippines).[[13]](https://en.wikipedia.org/wiki/.ph#cite_note-phildac-13) In like manner, .edu.ph was sub-delegated to the Philippine Network Foundation, Inc. (PHNET).[[14]](https://en.wikipedia.org/wiki/.ph#cite_note-14)

https://en.wikipedia.org/wiki/.ph#PH_Domain_Foundation_and_dotPH

## Singapore `.gov.sg`

I checked via https://en.wikipedia.org/wiki/.sg#Second-level_domains

It seems that some governmental websites are not using `.gov.sg`. We may want to add other ones when needed:
- Trusted Sites | gov.sg - https://www.gov.sg/trusted-sites#govsites

## Vietnam `.gov.vn`

I checked via .vn - Wikipedia - https://en.wikipedia.org/wiki/.vn#Second-level_domains
